### PR TITLE
When Effekseer library is missing, show a warning

### DIFF
--- a/src/CastleEffekseer.pas
+++ b/src/CastleEffekseer.pas
@@ -224,25 +224,29 @@ begin
 
   if EfkManager = nil then
   begin
-    {$if defined(ANDROID) or defined(IOS)}
-      RenderBackend := EfkMobileRenderBackend;
-    {$else}
-      RenderBackend := EfkDesktopRenderBackend;
-    {$endif}
-    WriteStr(RenderBackendName, RenderBackend);
-    WritelnLog('Effekseer''s render backend: ' + RenderBackendName);
-    EfkManager := EFK_Manager_Create(EfkMaximumNumberOfSprites);
-    EfkRenderer := EFK_Renderer_Create(EfkMaximumNumberOfSprites, RenderBackend, True);
+    if EFK_Load then
+    begin
+      {$if defined(ANDROID) or defined(IOS)}
+        RenderBackend := EfkMobileRenderBackend;
+      {$else}
+        RenderBackend := EfkDesktopRenderBackend;
+      {$endif}
+      WriteStr(RenderBackendName, RenderBackend);
+      WritelnLog('Effekseer''s render backend: ' + RenderBackendName);
+      EfkManager := EFK_Manager_Create(EfkMaximumNumberOfSprites);
+      EfkRenderer := EFK_Renderer_Create(EfkMaximumNumberOfSprites, RenderBackend, True);
 
-    EFK_Loader_RegisterLoadRoutine(@LoaderLoad);
-    EFK_Loader_RegisterFreeRoutine(@LoaderFree);
-    if EfkUseCGEImageLoader then
-      EFK_Loader_RegisterLoadImageFromFileRoutine(@LoaderLoadImageFromFile);
+      EFK_Loader_RegisterLoadRoutine(@LoaderLoad);
+      EFK_Loader_RegisterFreeRoutine(@LoaderFree);
+      if EfkUseCGEImageLoader then
+        EFK_Loader_RegisterLoadImageFromFileRoutine(@LoaderLoadImageFromFile);
 
-    EFK_Manager_SetDefaultRenders(EfkManager, EfkRenderer);
-    EFK_Manager_SetDefaultLoaders(EfkManager, EfkRenderer);
+      EFK_Manager_SetDefaultRenders(EfkManager, EfkRenderer);
+      EFK_Manager_SetDefaultLoaders(EfkManager, EfkRenderer);
 
-    ApplicationProperties.OnGLContextClose.Add(@FreeEfkContext);
+      ApplicationProperties.OnGLContextClose.Add(@FreeEfkContext);
+    end else
+      WritelnWarning('Effekseer', 'Could not load the Effekseer library.  Make sure you placed the relevant libraries (libeffekseer.dll, libeffekseer.so...) inside the project. On Unix, also make sure you run with LD_LIBRARY_PATH pointing to these libraries.');
   end;
 
   Self.FIsGLContextInitialized := True;
@@ -455,8 +459,6 @@ begin
 end;
 
 initialization
-  if not EFK_Load then
-    raise Exception.Create('Cannot initialize Effekseer library!');
   RegisterSerializableComponent(TCastleEffekseer, 'Effekseer Emitter');
   EfkEffectCache := TEfkEffectCache.Create;
 

--- a/src/effekseer.pas
+++ b/src/effekseer.pas
@@ -67,10 +67,14 @@ function EFK_Load: Boolean;
 
 implementation
 
-function EFK_Load: Boolean;
 var
   Lib: TLibHandle = dynlibs.NilHandle;
+
+function EFK_Load: Boolean;
 begin;
+  // library already loaded, subsequent calls to EFK_Load do nothing
+  if Lib <> dynlibs.NilHandle then Exit(True);
+
   Lib := LoadLibrary(EFKLIB);
   if Lib = dynlibs.NilHandle then Exit(False);
 


### PR DESCRIPTION
I was testing the cge-effekseer custom components with CGE editor on Windows. In general I admit we don't handle perfectly in CGE the situation when a component requires some external library (DLL, SO), even at design-time, to work -- though this PR will improve how it works for users.

Right now, `CastleEffekseer` checks in initialization whether `EFK_Load` is successfull, and if not it raises exception.

1. In CGE we don't have any reliable facility to run custom editor with custom libraries (dll, so), like Effekseer or FMOD. We don't even have a clean way to define such non-standard library dependencies on desktops (on mobile, we have Android/iOS "services").

    I changed the code in CGE https://github.com/castle-engine/castle-engine/commit/017171d6e3b475becb2875c0b154dc6b22737d45 that runs custom editor, so that at least it runs with current directory = project directory, so that it will now work on Windows (will use `libeffekseer.dll` if placed in the main project directory). This is more a hack than a real solution -- it will not work on Linux (where one has to define LD_LIBRARY_PATH), and it's a thing easy to miss, and it actually locks the DLL on Windows if the custom editor is running. But at least it will work on Windows if you just do there "Restart Editor (With Custom Components)".

    The long-term solution is in my mind to allow creation+usage of "services" that contain platform-specific libraries (dll, so) on desktops (Windows, Linux...). I have this planned since some time (not only for Effekseer, also to e.g. use FMOD sound backend in the editor). Such services would provide all the information to include the library for editor too.

2. If the library is not available, we don't react nicely in CastleEffekseer.

    For some reason, the exception when Effekseer library is missing is not visible when you run the custom editor exe. The editor instead closes silently. Running it in Lazarus debugger shows it correctly raises `raise Exception.Create('Cannot initialize Effekseer library!')`, but it is not visible to user in any way. Possibly the exception so early in `initialization` does not result in the proper "exit handler" executed by FPC?

I didn't investigate AD 2 more, as I thought that maybe the exception at load should be just avoided. Instead, `TCastleEffekseer` could just make a warning when `EFK_Load` is not true. This way, while the CGE problem AD 1 remains unaddressed yet, at least we react nicer to the missing library -- nothing crashes, custom editor always works, you can open the design with `TCastleEffekseer`. You will just not see the effect (and will have a clear warning) when the library is not available.
