### PR TITLE
Setting TCastleEffekseer.URL to empty should just unload the effect

### DIFF
--- a/src/CastleEffekseer.pas
+++ b/src/CastleEffekseer.pas
@@ -224,25 +224,29 @@ begin
 
   if EfkManager = nil then
   begin
-    {$if defined(ANDROID) or defined(IOS)}
-      RenderBackend := EfkMobileRenderBackend;
-    {$else}
-      RenderBackend := EfkDesktopRenderBackend;
-    {$endif}
-    WriteStr(RenderBackendName, RenderBackend);
-    WritelnLog('Effekseer''s render backend: ' + RenderBackendName);
-    EfkManager := EFK_Manager_Create(EfkMaximumNumberOfSprites);
-    EfkRenderer := EFK_Renderer_Create(EfkMaximumNumberOfSprites, RenderBackend, True);
+    if EFK_Load then
+    begin
+      {$if defined(ANDROID) or defined(IOS)}
+        RenderBackend := EfkMobileRenderBackend;
+      {$else}
+        RenderBackend := EfkDesktopRenderBackend;
+      {$endif}
+      WriteStr(RenderBackendName, RenderBackend);
+      WritelnLog('Effekseer''s render backend: ' + RenderBackendName);
+      EfkManager := EFK_Manager_Create(EfkMaximumNumberOfSprites);
+      EfkRenderer := EFK_Renderer_Create(EfkMaximumNumberOfSprites, RenderBackend, True);
 
-    EFK_Loader_RegisterLoadRoutine(@LoaderLoad);
-    EFK_Loader_RegisterFreeRoutine(@LoaderFree);
-    if EfkUseCGEImageLoader then
-      EFK_Loader_RegisterLoadImageFromFileRoutine(@LoaderLoadImageFromFile);
+      EFK_Loader_RegisterLoadRoutine(@LoaderLoad);
+      EFK_Loader_RegisterFreeRoutine(@LoaderFree);
+      if EfkUseCGEImageLoader then
+        EFK_Loader_RegisterLoadImageFromFileRoutine(@LoaderLoadImageFromFile);
 
-    EFK_Manager_SetDefaultRenders(EfkManager, EfkRenderer);
-    EFK_Manager_SetDefaultLoaders(EfkManager, EfkRenderer);
+      EFK_Manager_SetDefaultRenders(EfkManager, EfkRenderer);
+      EFK_Manager_SetDefaultLoaders(EfkManager, EfkRenderer);
 
-    ApplicationProperties.OnGLContextClose.Add(@FreeEfkContext);
+      ApplicationProperties.OnGLContextClose.Add(@FreeEfkContext);
+    end else
+      WritelnWarning('Effekseer', 'Could not load the Effekseer library.  Make sure you placed the relevant libraries (libeffekseer.dll, libeffekseer.so...) inside the project. On Unix, also make sure you run with LD_LIBRARY_PATH pointing to these libraries.');
   end;
 
   Self.FIsGLContextInitialized := True;
@@ -455,8 +459,6 @@ begin
 end;
 
 initialization
-  if not EFK_Load then
-    raise Exception.Create('Cannot initialize Effekseer library!');
   RegisterSerializableComponent(TCastleEffekseer, 'Effekseer Emitter');
   EfkEffectCache := TEfkEffectCache.Create;
 

--- a/src/effekseer.pas
+++ b/src/effekseer.pas
@@ -67,10 +67,14 @@ function EFK_Load: Boolean;
 
 implementation
 
-function EFK_Load: Boolean;
 var
   Lib: TLibHandle = dynlibs.NilHandle;
+
+function EFK_Load: Boolean;
 begin;
+  // library already loaded, subsequent calls to EFK_Load do nothing
+  if Lib <> dynlibs.NilHandle then Exit(True);
+
   Lib := LoadLibrary(EFKLIB);
   if Lib = dynlibs.NilHandle then Exit(False);
 


### PR DESCRIPTION
( This PR is done on top of https://github.com/Kagamma/cge-effekseer/pull/2 , i.e. it contains also commits from https://github.com/Kagamma/cge-effekseer/pull/2 . If you apply https://github.com/Kagamma/cge-effekseer/pull/2 first, then the contents of this PR will simplify into a single new commit. )

It is a CGE convention that setting URL to '' is allowed, and means "unload the currently loaded thing" (it works at least with `TCastleScene.URL`, `TCastleImageControl.URL`, `TCastleDesign.URL`, `TCastleTransformDesign.URL`).

This also allows user to reliably reload the model in CGE editor inspector by using a magic sequence in the URL field _Ctrl + A, Ctrl + X, Enter, Ctrl + V, Enter_. Of course we plan to make it more comfortable in the future (adding a button to URL fields to reload, maybe also detecting changes in assets and reloading automatically), maybe by doing `OldURL := URL; URL := ''; URL := OldURL;` under the hood or maybe by calling special `ReloadURL`.

This PR changes `TCastleEffekseer.URL` setting behavior to follow this convention. We actually change `TCastleEffekseer.InternalRefreshEffect` implementation, to make it possible. Setting `URL` to '' is now valid and just clears the previous effect.
