### PR TITLE
Tolerate missing textures

### DIFF
--- a/demos/TestEffekseer/.gitignore
+++ b/demos/TestEffekseer/.gitignore
@@ -1,0 +1,12 @@
+# Windows executable
+*.exe
+# Unix executable
+TestEffekseer
+
+# libraries
+*.dll
+*.so
+
+# CGE compilation output
+castle-engine-output
+*.res

--- a/src/CastleEffekseer.pas
+++ b/src/CastleEffekseer.pas
@@ -224,25 +224,29 @@ begin
 
   if EfkManager = nil then
   begin
-    {$if defined(ANDROID) or defined(IOS)}
-      RenderBackend := EfkMobileRenderBackend;
-    {$else}
-      RenderBackend := EfkDesktopRenderBackend;
-    {$endif}
-    WriteStr(RenderBackendName, RenderBackend);
-    WritelnLog('Effekseer''s render backend: ' + RenderBackendName);
-    EfkManager := EFK_Manager_Create(EfkMaximumNumberOfSprites);
-    EfkRenderer := EFK_Renderer_Create(EfkMaximumNumberOfSprites, RenderBackend, True);
+    if EFK_Load then
+    begin
+      {$if defined(ANDROID) or defined(IOS)}
+        RenderBackend := EfkMobileRenderBackend;
+      {$else}
+        RenderBackend := EfkDesktopRenderBackend;
+      {$endif}
+      WriteStr(RenderBackendName, RenderBackend);
+      WritelnLog('Effekseer''s render backend: ' + RenderBackendName);
+      EfkManager := EFK_Manager_Create(EfkMaximumNumberOfSprites);
+      EfkRenderer := EFK_Renderer_Create(EfkMaximumNumberOfSprites, RenderBackend, True);
 
-    EFK_Loader_RegisterLoadRoutine(@LoaderLoad);
-    EFK_Loader_RegisterFreeRoutine(@LoaderFree);
-    if EfkUseCGEImageLoader then
-      EFK_Loader_RegisterLoadImageFromFileRoutine(@LoaderLoadImageFromFile);
+      EFK_Loader_RegisterLoadRoutine(@LoaderLoad);
+      EFK_Loader_RegisterFreeRoutine(@LoaderFree);
+      if EfkUseCGEImageLoader then
+        EFK_Loader_RegisterLoadImageFromFileRoutine(@LoaderLoadImageFromFile);
 
-    EFK_Manager_SetDefaultRenders(EfkManager, EfkRenderer);
-    EFK_Manager_SetDefaultLoaders(EfkManager, EfkRenderer);
+      EFK_Manager_SetDefaultRenders(EfkManager, EfkRenderer);
+      EFK_Manager_SetDefaultLoaders(EfkManager, EfkRenderer);
 
-    ApplicationProperties.OnGLContextClose.Add(@FreeEfkContext);
+      ApplicationProperties.OnGLContextClose.Add(@FreeEfkContext);
+    end else
+      WritelnWarning('Effekseer', 'Could not load the Effekseer library.  Make sure you placed the relevant libraries (libeffekseer.dll, libeffekseer.so...) inside the project. On Unix, also make sure you run with LD_LIBRARY_PATH pointing to these libraries.');
   end;
 
   Self.FIsGLContextInitialized := True;
@@ -455,8 +459,6 @@ begin
 end;
 
 initialization
-  if not EFK_Load then
-    raise Exception.Create('Cannot initialize Effekseer library!');
   RegisterSerializableComponent(TCastleEffekseer, 'Effekseer Emitter');
   EfkEffectCache := TEfkEffectCache.Create;
 

--- a/src/CastleEffekseer.pas
+++ b/src/CastleEffekseer.pas
@@ -165,10 +165,12 @@ begin
   end;
 end;
 
-{ Free FP's Stream object }
-procedure LoaderFree(MS: TMemoryStream); cdecl;
+{ Free an object.
+  The argument is either TCastleImage (when it is a texture loaded by LoadImageFromFile)
+  or a TMemoryStream (when it is a stream loaded by LoaderLoad). }
+procedure LoaderFree(O: TObject); cdecl;
 begin
-  FreeAndNil(MS);
+  FreeAndNil(O);
 end;
 
 { ----- TEfkEffectCache ----- }

--- a/src/effekseer.pas
+++ b/src/effekseer.pas
@@ -67,10 +67,14 @@ function EFK_Load: Boolean;
 
 implementation
 
-function EFK_Load: Boolean;
 var
   Lib: TLibHandle = dynlibs.NilHandle;
+
+function EFK_Load: Boolean;
 begin;
+  // library already loaded, subsequent calls to EFK_Load do nothing
+  if Lib <> dynlibs.NilHandle then Exit(True);
+
   Lib := LoadLibrary(EFKLIB);
   if Lib = dynlibs.NilHandle then Exit(False);
 

--- a/wrapper/main.cpp
+++ b/wrapper/main.cpp
@@ -120,10 +120,13 @@ public:
 		//
 		if (loader_loadImageFromFile != nullptr) {
 			loader_loadImageFromFile(path, &objPas, &pixels, &width, &height, &bpp);
+                        // in case texture failed to load, Pascal LoaderLoadImageFromFile sets both objPas and pixels to nullptr
+                        if (pixels == nullptr) return nullptr;
 		} else {
 			loader_load(path, &objPas, &data, &size);
-			pixels = (uint8_t*)stbi_load_from_memory((stbi_uc const*)data, size, &width, &height, &bpp, 0);
+                        // in case stream failed to load, Pascal LoaderLoad sets both objPas and data to nullptr
 			if (data == nullptr) return nullptr;
+			pixels = (uint8_t*)stbi_load_from_memory((stbi_uc const*)data, size, &width, &height, &bpp, 0);
 		}
 
 		textureData.resize(width * height * 4);

--- a/wrapper/main.cpp
+++ b/wrapper/main.cpp
@@ -124,7 +124,7 @@ public:
                         if (pixels == nullptr) return nullptr;
 		} else {
 			loader_load(path, &objPas, &data, &size);
-                        // in case stream failed to load, Pascal LoaderLoad sets both objPas and data to nullptr
+			// in case stream failed to load, Pascal LoaderLoad sets both objPas and data to nullptr
 			if (data == nullptr) return nullptr;
 			pixels = (uint8_t*)stbi_load_from_memory((stbi_uc const*)data, size, &width, &height, &bpp, 0);
 		}

--- a/wrapper/main.cpp
+++ b/wrapper/main.cpp
@@ -120,8 +120,8 @@ public:
 		//
 		if (loader_loadImageFromFile != nullptr) {
 			loader_loadImageFromFile(path, &objPas, &pixels, &width, &height, &bpp);
-                        // in case texture failed to load, Pascal LoaderLoadImageFromFile sets both objPas and pixels to nullptr
-                        if (pixels == nullptr) return nullptr;
+			// in case texture failed to load, Pascal LoaderLoadImageFromFile sets both objPas and pixels to nullptr
+			if (pixels == nullptr) return nullptr;
 		} else {
 			loader_load(path, &objPas, &data, &size);
 			// in case stream failed to load, Pascal LoaderLoad sets both objPas and data to nullptr


### PR DESCRIPTION
( This PR is done on top of #4 . If you apply #4 first, then the contents of this PR will simplify into just 3 new commits. )

When the textures are missing for the Effekseer asset, weird things happened:

- On Windows I did experience crashes (Access Violations),  as C++ code in `wrapper/main.cpp` was accessing data under null pointer `pixels`

- On Linux I experienced rendering bug (as I supposed width / height have wild random values)

That both seems to be because C++ code doesn't check and exit when `LoaderLoadImageFromFile` sets `objPas` and `pixels` to `nullptr`.

This is reproducible by `demos/TestEffekseer/`, just remove/rename the textures in `demos/TestEffekseer/data/efk/Texture`.

Looking at code in `wrapper/main.cpp`, also the branch when `loader_loadImageFromFile` is null in C++ (so `EfkUseCGEImageLoader` is `false` in Pascal) deserved a small fix: it should exit when `if (data == nullptr) return nullptr;` earlier, without reading from null with `stbi_load_from_memory`.
