### PR TITLE
Use Params.AddRenderEvent, to compile and work with latest CGE

### DIFF
--- a/demos/TestEffekseer/code/gamestatemain.pas
+++ b/demos/TestEffekseer/code/gamestatemain.pas
@@ -50,7 +50,9 @@ begin
   { Find components, by name, that we need to access from code }
   Self.LabelFps := Self.DesignedComponent('LabelFps') as TCastleLabel;
   Self.Viewport := Self.DesignedComponent('Viewport') as TCastleViewport;
-  for I := 0 to 0 do
+  { Note: do not add with I = 0, as it would overlap with TCastleEffekseer
+    present already in designed castle-data:/gamestatemain.castle-user-interface }
+  for I := 1 to 3 do
   begin
     Emitter := TCastleEffekseer.Create(Self);
     Emitter.URL := 'castle-data:/efk/Laser01.efk';


### PR DESCRIPTION
Short version: This PR fixes the compilation and working of cge-effekseer with latest CGE. 

Long version:

- I broke cge-effekseer (but I explain below why! :) ) by recent CGE changes, merged to CGE master 2 days ago (September 4th), for https://github.com/castle-engine/castle-engine/issues/614#issuecomment-2327684489 .
- I have added now new API to make custom rendering (like done by cge-effekseer) work and cooperate nicely with new CGE approach. This is in https://github.com/castle-engine/castle-engine/commit/9e135b04e87e0a94db75df741d8e9a4799714b82 -- it's a fresh commit, and traditionally it will take a few hours before a release with it will be built and available on https://castle-engine.io/download .
- So, to anyone reading this, *be sure you test this with the very latest Castle Game Engine code from GitHub*.

Why and how?

In latest CGE, we have optimized rendering (for https://github.com/castle-engine/castle-engine/issues/614 ) to

- Call `TCastleTransform.LocalRender` *only once*.

- And later use the collected shapes list multiple times. 

    Without shadow volumes, it means we then use collected shapes 2 times: 1. filtering by shapes that are opaque, 2. filtering by shapes that use blending. 

    With shadow volumes, there are 4 different stages. The idea is the same, we reuse a single `AllCollectedShapes` list collected by one call of `TCastleTransform.LocalRender` over the entire tree.

This means that some `TRenderParams` parameters had to be removed, as they made no sense anymore: `Params.InShadow`, `Params.Transparent`, `Params.StencilTest` are gone.

There is a structure `TRenderOnePassParams`, passed around, that has some equivalents of these parameters:

- `TRenderOnePassParams.UsingBlending` is essentially like previous `Params.Transparent`,
- `TRenderOnePassParams.InsideStencilTest` is like previous `Params.StencilTest > 0`,
- `TRenderOnePassParams.DisableShadowVolumeCastingLights` is like previous `Params.InShadow`.

... but the `TRenderOnePassParams` value is not available during `TCastleTransform.LocalRender`, and it cannot be -- as `TCastleTransform.LocalRender` runs once, and later we process collected shapes with various values in `TRenderOnePassParams`.

How to deal with it for custom rendering, like you do here, where your `TCastleTransform.LocalRender` cannot just _"add shapes to `Params.Collector`"_ because you don't have X3D shapes?

- The *wrong* solution would be just fixing compilation by removing looking at the removed `Params.Xxx`. That is, I could fix compilation of `cge-effekseer/demos/TestEffekseer/TestEffekseer_standalone.lpr` by just removing the check for `Params.InShadow or (not Params.Transparent) or (Params.StencilTest > 0)` inside the `TCastleEffekseer.LocalRender`... but this results in wrong rendering: as effectively the Effekseer rendering would be done once, before all shapes, and effectively we would treat all Effekseer rendering as opaque -- and so the effects would be rendered underneath opaque shapes.

- The *correct* solution, done in this PR: I have implemented in CGE now ability to provide a custom callback to perform later rendering, using `Params.AddRenderEvent`. The idea is, `TCastleTransform.LocalRender` calls `Params.AddRenderEvent` once, and then CGE calls the provided callback multiple times, with various values of `TRenderOnePassParams`.

    Going forward, this allows us to support custom rendering approaches like you do correctly and nicely. Right now `AddRenderEvent` just gets a callback, and the callback is called with transformation (`TTransformation`) and `TRenderOnePassParams`. More possibilities are possible in the future, e.g. we could get a box and sort the things provided to `AddRenderEvent` along with existing X3D shapes. So we can treat "custom rendered things" as 1st class citizens, giving them all features that our internal rendering of X3D shapes has too.

TODO: The name `TCastleTranssform.LocalRender` is now confusing, I know! (Just like `TRenderParams`.) It's not really a method where one should "render" anymore. It's a "collection phase". Think of it as `TCastleTranssform.CollectThingsToRender(const Params: ...)` and bear with me as I figure out a non-confusing naming  around this. 
